### PR TITLE
Fix type errors in product page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,8 +4,38 @@ import { useQuery } from "@apollo/client";
 import client from "@/lib/apollo";
 import { GET_PRODUCTS } from "@/lib/queries";
 
+interface Category {
+  name: string;
+}
+
+interface Size {
+  label: string;
+}
+
+interface Color {
+  name: string;
+  hexCode: string;
+}
+
+interface Image {
+  url: string;
+}
+
+interface Product {
+  name: string;
+  price: number;
+  category?: Category | null;
+  sizes: Size[];
+  colors: Color[];
+  images: Image[];
+}
+
+interface ProductsData {
+  products: Product[];
+}
+
 export default function Home() {
-  const { data, loading, error } = useQuery(GET_PRODUCTS, { client });
+  const { data, loading, error } = useQuery<ProductsData>(GET_PRODUCTS, { client });
 
   if (loading) return <p className="p-6">Loading...</p>;
   if (error) return <p className="p-6 text-red-600">Error: {error.message}</p>;
@@ -14,7 +44,7 @@ export default function Home() {
     <main className="p-8">
       <h1 className="text-3xl font-bold mb-6">T-shirts</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {data?.products?.map((product: any, i: number) => (
+        {data?.products?.map((product: Product, i: number) => (
           <div
             key={i}
             className="border p-4 rounded-lg shadow hover:shadow-md transition"
@@ -32,10 +62,10 @@ export default function Home() {
               Category: {product.category?.name}
             </p>
             <p className="text-sm text-gray-500">
-              Sizes: {product.sizes.map((s: any) => s.label).join(", ")}
+              Sizes: {product.sizes.map((s: Size) => s.label).join(", ")}
             </p>
             <div className="flex gap-2 mt-2">
-              {product.colors.map((c: any, idx: number) => (
+              {product.colors.map((c: Color, idx: number) => (
                 <div
                   key={idx}
                   className="w-5 h-5 rounded-full border"


### PR DESCRIPTION
## Summary
- add missing TypeScript interfaces for product data
- type `useQuery` call and map functions

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68797209f0bc832896bc04bc3d09fa30