### PR TITLE
Implement FashionED landing page with dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## FashionED Landing Page
+
+This project includes a demo home page for the **FashionED** e-commerce brand. It features a starfield background and a dark mode toggle. Use the navigation links or smooth scrolling buttons to jump between sections.
+
 ## Getting Started
 
-First, run the development server:
+First, install dependencies and run the development server:
 
 ```bash
+# install dependencies
+npm install
+
+# then start the dev server
 npm run dev
 # or
 yarn dev
@@ -15,6 +23,8 @@ bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+The starfield effect is drawn on a canvas behind the content. Colors adjust when the theme changes via `next-themes`. Navigation links and buttons simply use anchors so scrolling is handled smoothly by the browser.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.13.8",
+        "@heroicons/react": "^2.2.0",
         "graphql": "^16.11.0",
         "next": "15.4.1",
+        "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0"
       },
@@ -276,6 +278,15 @@
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4828,6 +4839,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "@apollo/client": "^3.13.8",
+    "@heroicons/react": "^2.2.0",
     "graphql": "^16.11.0",
     "next": "15.4.1",
+    "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0"
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,11 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+@layer base {
+  html {
+    @apply scroll-smooth;
   }
-}
-
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  body {
+    @apply bg-white text-gray-900 dark:bg-black dark:text-gray-100 transition-colors duration-300 antialiased;
+    font-family: var(--font-geist-sans);
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider } from "next-themes";
+import StarBackground from "@/components/StarBackground";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,11 +25,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <StarBackground />
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,82 +1,17 @@
-"use client";
-
-import { useQuery } from "@apollo/client";
-import client from "@/lib/apollo";
-import { GET_PRODUCTS } from "@/lib/queries";
-
-interface Category {
-  name: string;
-}
-
-interface Size {
-  label: string;
-}
-
-interface Color {
-  name: string;
-  hexCode: string;
-}
-
-interface Image {
-  url: string;
-}
-
-interface Product {
-  name: string;
-  price: number;
-  category?: Category | null;
-  sizes: Size[];
-  colors: Color[];
-  images: Image[];
-}
-
-interface ProductsData {
-  products: Product[];
-}
+import Navbar from "@/components/Navbar";
+import Hero from "@/components/Hero";
+import { AllProducts, Trendings, AboutSection } from "@/components/Sections";
 
 export default function Home() {
-  const { data, loading, error } = useQuery<ProductsData>(GET_PRODUCTS, { client });
-
-  if (loading) return <p className="p-6">Loading...</p>;
-  if (error) return <p className="p-6 text-red-600">Error: {error.message}</p>;
-
   return (
-    <main className="p-8">
-      <h1 className="text-3xl font-bold mb-6">T-shirts</h1>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {data?.products?.map((product: Product, i: number) => (
-          <div
-            key={i}
-            className="border p-4 rounded-lg shadow hover:shadow-md transition"
-          >
-            {product.images?.[0]?.url && (
-              <img
-                src={`http://localhost:1337${product.images[0].url}`}
-                alt={product.name}
-                className="mb-4 w-full h-48 object-cover rounded"
-              />
-            )}
-            <h2 className="text-xl font-semibold">{product.name}</h2>
-            <p className="text-gray-600">${product.price}</p>
-            <p className="text-sm text-gray-500">
-              Category: {product.category?.name}
-            </p>
-            <p className="text-sm text-gray-500">
-              Sizes: {product.sizes.map((s: Size) => s.label).join(", ")}
-            </p>
-            <div className="flex gap-2 mt-2">
-              {product.colors.map((c: Color, idx: number) => (
-                <div
-                  key={idx}
-                  className="w-5 h-5 rounded-full border"
-                  style={{ backgroundColor: c.hexCode }}
-                  title={c.name}
-                ></div>
-              ))}
-            </div>
-          </div>
-        ))}
-      </div>
-    </main>
+    <>
+      <Navbar />
+      <main className="pt-16">
+        <Hero />
+        <AllProducts />
+        <Trendings />
+        <AboutSection />
+      </main>
+    </>
   );
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,18 @@
+export default function Hero() {
+  return (
+    <section
+      id="hero"
+      className="min-h-screen flex flex-col items-center justify-center text-center"
+    >
+      <h1 className="text-5xl md:text-7xl font-bold italic mb-8">FashionED</h1>
+      <div className="space-x-4">
+        <a href="#products" className="px-6 py-3 bg-indigo-600 text-white rounded hover:shadow-lg hover:scale-105 transition">
+          Browse Products
+        </a>
+        <a href="#about" className="px-6 py-3 bg-gray-200 dark:bg-gray-700 dark:text-white rounded hover:shadow-lg hover:scale-105 transition">
+          Learn More
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,27 @@
+"use client";
+import Link from "next/link";
+import ThemeToggle from "./ThemeToggle";
+
+export default function Navbar() {
+  return (
+    <nav className="fixed top-0 left-0 w-full z-20 backdrop-blur bg-white/70 dark:bg-black/70">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 flex items-center justify-between h-16">
+        <Link href="#hero" className="text-2xl font-semibold italic">
+          FashionED
+        </Link>
+        <div className="flex items-center gap-6">
+          <Link href="#products" className="hover:underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            All Products
+          </Link>
+          <Link href="#trending" className="hover:underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            Trendings
+          </Link>
+          <Link href="#about" className="hover:underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            About Section
+          </Link>
+          <ThemeToggle />
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/Sections.tsx
+++ b/src/components/Sections.tsx
@@ -1,0 +1,28 @@
+export function AllProducts() {
+  return (
+    <section id="products" className="min-h-screen py-20 px-4">
+      <h2 className="text-3xl font-semibold mb-4">All Products</h2>
+      <p className="text-gray-600 dark:text-gray-400">Product list will go here.</p>
+    </section>
+  );
+}
+
+export function Trendings() {
+  return (
+    <section id="trending" className="min-h-screen py-20 px-4">
+      <h2 className="text-3xl font-semibold mb-4">Trendings</h2>
+      <p className="text-gray-600 dark:text-gray-400">Trending items will be displayed here.</p>
+    </section>
+  );
+}
+
+export function AboutSection() {
+  return (
+    <section id="about" className="min-h-screen py-20 px-4">
+      <h2 className="text-3xl font-semibold mb-4">About FashionED</h2>
+      <p className="text-gray-600 dark:text-gray-400">
+        We are a modern fashion brand bringing you the latest trends.
+      </p>
+    </section>
+  );
+}

--- a/src/components/StarBackground.tsx
+++ b/src/components/StarBackground.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useRef, useEffect } from "react";
+import { useTheme } from "next-themes";
+
+export default function StarBackground() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    let animationFrame: number;
+    const resize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+    resize();
+    window.addEventListener("resize", resize);
+    const stars = Array.from({ length: 100 }, () => ({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      r: Math.random() * 1.5,
+      s: Math.random() * 0.5 + 0.2,
+    }));
+    const draw = () => {
+      if (!ctx) return;
+      ctx.fillStyle = resolvedTheme === "dark" ? "#000" : "#f5faff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = resolvedTheme === "dark" ? "#fff" : "#94a3b8";
+      stars.forEach((star) => {
+        star.y += star.s;
+        if (star.y > canvas.height) {
+          star.y = 0;
+          star.x = Math.random() * canvas.width;
+        }
+        ctx.beginPath();
+        ctx.arc(star.x, star.y, star.r, 0, Math.PI * 2);
+        ctx.fill();
+      });
+      animationFrame = requestAnimationFrame(draw);
+    };
+    draw();
+    return () => {
+      window.removeEventListener("resize", resize);
+      cancelAnimationFrame(animationFrame);
+    };
+  }, [resolvedTheme]);
+
+  return (
+    <canvas ref={canvasRef} className="fixed inset-0 -z-10" />
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { SunIcon, MoonIcon } from "@heroicons/react/24/outline";
+
+export default function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+  const isDark = resolvedTheme === "dark";
+  return (
+    <button
+      aria-label="Toggle Dark Mode"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className="p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition"
+    >
+      {isDark ? (
+        <SunIcon className="w-5 h-5" />
+      ) : (
+        <MoonIcon className="w-5 h-5" />
+      )}
+    </button>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: [
+    './src/**/*.{ts,tsx}',
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+
+export default config


### PR DESCRIPTION
## Summary
- set up Tailwind with class-based dark mode
- wrap app with `next-themes` provider and starfield background
- add navbar, hero, section placeholders and theme toggle
- implement animated starfield reacting to theme
- document running the project and features

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c44da0f3083289d3b4045d9147b34